### PR TITLE
Fix ads deletion flow

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -135,7 +135,7 @@
   });
 })();
 jQuery(document).ready(function($) {
-    $(document).on('click', '.order-delete', function(e) {
+$(document).on('click', '.order-delete', function(e) {
         e.preventDefault();
 
         var orderId = $(this).data('order-id'); // Получаем ID заказа из кнопки
@@ -159,4 +159,42 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+    // ---------- Подтверждение удаления объявления ----------
+    const modal   = document.getElementById('ad-delete-modal');
+    if (modal) {
+        const yesBtn = modal.querySelector('.confirm-yes');
+        const noBtn  = modal.querySelector('.confirm-no');
+        let action = null;
+
+        document.addEventListener('click', function(ev){
+            const link = ev.target.closest('.ads-delete');
+            const btn  = ev.target.closest('.ad-delete-btn');
+            if (!link && !btn) return;
+            ev.preventDefault();
+
+            if (link) {
+                const href = link.getAttribute('href');
+                action = function(){ window.location.href = href; };
+            }
+
+            if (btn) {
+                const form = btn.closest('form');
+                action = function(){ form.submit(); };
+            }
+
+            modal.classList.remove('hidden');
+        });
+
+        yesBtn.addEventListener('click', function(){
+            modal.classList.add('hidden');
+            if (typeof action === 'function') action();
+            action = null;
+        });
+
+        noBtn.addEventListener('click', function(){
+            modal.classList.add('hidden');
+            action = null;
+        });
+    }
 });

--- a/inc/dashboard/ad-editor.php
+++ b/inc/dashboard/ad-editor.php
@@ -176,8 +176,7 @@ $city        = $is_edit ? get_post_meta( $post_id, '_city', true ) : '';
     <div class="form-row ad-actions-full">
       <button type="submit" class="btn btn-submit"><?php esc_html_e('Сохранить','my-custom-theme');?></button>
       <?php if($is_edit):?>
-        <button type="submit" name="ad_delete" value="1" class="btn btn-secondary"
-                onclick="return confirm('<?php echo esc_js(__('Удалить?','my-custom-theme'));?>');"><?php esc_html_e('Удалить','my-custom-theme');?></button>
+        <button type="submit" name="ad_delete" value="1" class="btn btn-secondary ad-delete-btn"><?php esc_html_e('Удалить','my-custom-theme');?></button>
       <?php endif;?>
     </div>
 

--- a/inc/dashboard/dashboard-functions.php
+++ b/inc/dashboard/dashboard-functions.php
@@ -139,7 +139,14 @@ function mytheme_handle_delete_ad() {
         wp_die( __( 'У вас нет прав для удаления этого объявления.', 'my-custom-theme' ) );
     }
     wp_trash_post( $ad_id );
-    wp_safe_redirect( remove_query_arg( [ 'mode', 'ad_id', '_wpnonce' ], get_permalink( get_queried_object_id() ) ) );
+
+    // Возвращаем пользователя в раздел объявлений
+    $redirect_url = add_query_arg(
+        'section',
+        'ads',
+        get_permalink( get_queried_object_id() )
+    );
+    wp_safe_redirect( $redirect_url );
     exit;
 }
 

--- a/page-account.php
+++ b/page-account.php
@@ -217,27 +217,35 @@ case 'ads':
 				</a>
 
 				<!-- Удалить -->
-				<a class="btn btn--small btn--danger ads-delete"
-				   href="<?php echo esc_url( wp_nonce_url(
-					   add_query_arg(
-						   [
-							   'section' => 'ads',
-							   'mode'    => 'delete',      // обработчик удаления
-							   'ad_id'   => get_the_ID(),
-						   ],
-						   $account_page_url
-					   ),
-					   'mytheme_delete_ad_' . get_the_ID()
-				   ) ); ?>"
-				   onclick="return confirm('<?php echo esc_js( __( 'Удалить объявление?', 'my-custom-theme' ) ); ?>');">
-					<?php esc_html_e( 'Удалить', 'my-custom-theme' ); ?>
-				</a>
-			</div>
+                                <a class="btn btn--small btn--danger ads-delete"
+                                   href="<?php echo esc_url( wp_nonce_url(
+                                           add_query_arg(
+                                                   [
+                                                           'section' => 'ads',
+                                                           'mode'    => 'delete',      // обработчик удаления
+                                                           'ad_id'   => get_the_ID(),
+                                                   ],
+                                                   $account_page_url
+                                           ),
+                                           'mytheme_delete_ad_' . get_the_ID()
+                                   ) ); ?>">
+                                        <?php esc_html_e( 'Удалить', 'my-custom-theme' ); ?>
+                                </a>
+                        </div>
 
 		</div>
 	<?php endwhile;
 	wp_reset_postdata();
-	echo '</div>'; /* .ads-grid */
+        echo '</div>'; /* .ads-grid */
+
+        // Модальное окно подтверждения удаления
+        echo '<div id="ad-delete-modal" class="confirm-overlay hidden">'
+           . '<div class="confirm-box">'
+           . '<p>' . esc_html__( 'Удалить объявление?', 'my-custom-theme' ) . '</p>'
+           . '<div class="confirm-buttons">'
+           . '<button type="button" class="btn btn--danger confirm-yes">' . esc_html__( 'Удалить', 'my-custom-theme' ) . '</button>'
+           . '<button type="button" class="btn confirm-no">' . esc_html__( 'Отмена', 'my-custom-theme' ) . '</button>'
+           . '</div></div></div>';
 
 	/* ---------- пагинация ---------- */
 	echo '<div class="ads-pagination">';

--- a/style.css
+++ b/style.css
@@ -1666,3 +1666,10 @@ ul.flex-control-thumbs li {max-width:90px;}
 
 /* 6. строка «Продавец» (если выводится через PHP-хук) */
 .product-vendor{margin:.75rem 0 0; font-size:.9rem;}
+
+/* === Confirm modal for ads delete === */
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;z-index:9999;}
+.confirm-overlay.hidden{display:none;}
+.confirm-box{background:#fff;padding:20px;border-radius:6px;max-width:320px;text-align:center;}
+.confirm-buttons{margin-top:15px;display:flex;justify-content:center;gap:10px;}
+


### PR DESCRIPTION
## Summary
- add custom modal confirmation for deleting ads
- ensure redirect after deletion returns to ads section
- integrate modal handling script
- tweak ad editor delete button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869129f02988321bf95c58630809a4e