### PR TITLE
Fix catalog listing and filters

### DIFF
--- a/inc/catalog/catalog-section.php
+++ b/inc/catalog/catalog-section.php
@@ -13,16 +13,39 @@ if ( ! isset( $term ) || is_wp_error( $term ) ) {
 }
 
 // Параметры фильтрации
-$current_orderby = sanitize_text_field( wp_unslash( $_GET['orderby']  ?? 'date' ) );
-$current_per     = intval(           wp_unslash( $_GET['per_page'] ?? 10   ) );
+$current_orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ?? 'date_desc' ) );
+$current_per     = intval(           wp_unslash( $_GET['per_page'] ?? 10       ) );
+$search_term     = sanitize_text_field( wp_unslash( $_GET['s']       ?? ''        ) );
 $paged           = max( 1, get_query_var( 'paged', 1 ) );
-$order           = ( 'date' === $current_orderby ) ? 'DESC' : 'ASC';
+
+$order    = 'DESC';
+$orderby  = 'date';
+$meta_key = '';
+switch ( $current_orderby ) {
+    case 'date_asc':
+        $order   = 'ASC';
+        $orderby = 'date';
+        break;
+    case 'price_desc':
+        $order    = 'DESC';
+        $orderby  = 'meta_value_num';
+        $meta_key = '_price';
+        break;
+    case 'price_asc':
+        $order    = 'ASC';
+        $orderby  = 'meta_value_num';
+        $meta_key = '_price';
+        break;
+    default:
+        $order   = 'DESC';
+        $orderby = 'date';
+}
 
 // Запрос товаров
 $args = array(
     'post_type'      => 'product',
     'posts_per_page' => $current_per,
-    'orderby'        => $current_orderby,
+    'orderby'        => $orderby,
     'order'          => $order,
     'paged'          => $paged,
     'tax_query'      => array(
@@ -33,6 +56,12 @@ $args = array(
         ),
     ),
 );
+if ( $meta_key ) {
+    $args['meta_key'] = $meta_key;
+}
+if ( $search_term ) {
+    $args['s'] = $search_term;
+}
 if ( isset( $_GET['used_only'] ) ) {
     $args['meta_query'][] = array(
         'key'     => '_condition',
@@ -53,7 +82,7 @@ $products = new WP_Query( $args );
     <!-- Поисковая строка -->
     <div class="filter-search">
       <label for="product-search-input"><?php esc_html_e( 'Search', 'my-custom-theme' ); ?></label>
-      <input type="text" id="product-search-input" placeholder="<?php esc_attr_e( 'Search by title...', 'my-custom-theme' ); ?>">
+      <input type="text" id="product-search-input" name="s" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Search by title...', 'my-custom-theme' ); ?>">
       <div id="search-suggestions" class="search-suggestions"></div>
     </div>
 
@@ -61,8 +90,10 @@ $products = new WP_Query( $args );
       <label>
         <?php esc_html_e( 'Sort by', 'my-custom-theme' ); ?>
         <select name="orderby">
-          <option value="date" <?php selected( $current_orderby, 'date' ); ?>><?php esc_html_e( 'Date Descending', 'my-custom-theme' ); ?></option>
-          <option value="title" <?php selected( $current_orderby, 'title' ); ?>><?php esc_html_e( 'Title',            'my-custom-theme' ); ?></option>
+          <option value="date_desc"  <?php selected( $current_orderby, 'date_desc'  ); ?>><?php esc_html_e( 'Date Descending',  'my-custom-theme' ); ?></option>
+          <option value="date_asc"   <?php selected( $current_orderby, 'date_asc'   ); ?>><?php esc_html_e( 'Date Ascending',   'my-custom-theme' ); ?></option>
+          <option value="price_desc" <?php selected( $current_orderby, 'price_desc' ); ?>><?php esc_html_e( 'Price Descending', 'my-custom-theme' ); ?></option>
+          <option value="price_asc"  <?php selected( $current_orderby, 'price_asc'  ); ?>><?php esc_html_e( 'Price Ascending',  'my-custom-theme' ); ?></option>
         </select>
       </label>
       <label>
@@ -99,6 +130,7 @@ $products = new WP_Query( $args );
       'mid_size'  => 1,
       'prev_text' => '«',
       'next_text' => '»',
+      'total'     => $products->max_num_pages,
     ) ); ?>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -774,6 +774,15 @@ img { max-width: 100%; height: auto; display: block; }
 .ads-pagination .page-numbers:hover{
   background:#21403c;color:#fff;border-color:#21403c;
 }
+.products-pagination{margin-top:30px;text-align:center;}
+.products-pagination .page-numbers{
+  display:inline-block;margin:0 4px;padding:6px 10px;
+  border:1px solid #ccc;border-radius:4px;
+}
+.products-pagination .current,
+.products-pagination .page-numbers:hover{
+  background:#21403c;color:#fff;border-color:#21403c;
+}
 /* ===== 16. Orders accordion clean ===== */
 
 /* строка деталей всегда видима как <tr> */


### PR DESCRIPTION
## Summary
- show products when navigating into subcategories
- enable searching, sorting, and pagination for catalog views
- style the new `.products-pagination` controls

## Testing
- `php -l page-products.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68691922bacc8321a0951f444cff6d58