### PR TITLE
Add category and subcategory selection in ad editor

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -197,4 +197,34 @@ $(document).on('click', '.order-delete', function(e) {
             action = null;
         });
     }
+
+    // ---------- Категории и подкатегории в редакторе объявлений ----------
+    const catSelect    = document.getElementById('ad_cat');
+    const subcatRow    = document.getElementById('subcat-row');
+    const subcatSelect = document.getElementById('ad_subcat');
+
+    function loadSubcats(catId, selected){
+        if(!catSelect || !subcatSelect || !subcatRow) return;
+        subcatSelect.innerHTML = '<option value="">Выберите…</option>';
+        if(!catId){
+            subcatRow.style.display = 'none';
+            return;
+        }
+        fetch(`${window.location.origin}/wp-json/wp/v2/product_cat?parent=${catId}&per_page=100`)
+            .then(r=>r.json())
+            .then(data=>{
+                if(Array.isArray(data) && data.length){
+                    subcatSelect.innerHTML = '<option value="">Выберите…</option>' +
+                        data.map(t=>`<option value="${t.id}" ${selected==t.id?'selected':''}>${t.name}</option>`).join('');
+                    subcatRow.style.display = '';
+                }else{
+                    subcatRow.style.display = 'none';
+                }
+            });
+    }
+
+    if(catSelect && subcatSelect && subcatRow){
+        catSelect.addEventListener('change', ()=>loadSubcats(parseInt(catSelect.value,10)||0));
+        loadSubcats(parseInt(catSelect.value,10)||0, parseInt(subcatSelect.dataset.selected||0,10));
+    }
 });

--- a/inc/dashboard/dashboard-functions.php
+++ b/inc/dashboard/dashboard-functions.php
@@ -55,9 +55,13 @@ function mytheme_handle_save_ad() {
     update_post_meta( $post_id, '_country',   sanitize_text_field( $_POST['ad_country']  ?? '' ) );
     update_post_meta( $post_id, '_city',      sanitize_text_field( $_POST['ad_city']     ?? '' ) );
 
-    // 5) Категория
-    if ( ! empty( $_POST['ad_cat'] ) ) {
-        wp_set_post_terms( $post_id, [ absint( $_POST['ad_cat'] ) ], 'product_cat' );
+    // 5) Категория и подкатегория
+    $cat_term    = absint( $_POST['ad_cat']     ?? 0 );
+    $subcat_term = absint( $_POST['ad_subcat']  ?? 0 );
+    if ( $subcat_term ) {
+        wp_set_post_terms( $post_id, [ $subcat_term ], 'product_cat' );
+    } elseif ( $cat_term ) {
+        wp_set_post_terms( $post_id, [ $cat_term ], 'product_cat' );
     }
 
     // 6) Собираем существующую галерею


### PR DESCRIPTION
## Summary
- restrict categories in the ad editor to Audio, Lightning, Visual, Rigging and Staging
- allow choosing subcategories depending on selected category
- save the subcategory when editing/creating ads
- add JS logic to dynamically load subcategories

## Testing
- `php -l inc/dashboard/ad-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694d80af388321a3035d94d6f6130b