### PR TITLE
Show subcategory dropdown in ad editor

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -203,6 +203,8 @@ $(document).on('click', '.order-delete', function(e) {
     const subcatRow    = document.getElementById('subcat-row');
     const subcatSelect = document.getElementById('ad_subcat');
 
+    const restUrl = `${window.location.origin}/wp-json/wp/v2/product_cat`;
+
     function loadSubcats(catId, selected){
         if(!catSelect || !subcatSelect || !subcatRow) return;
         subcatSelect.innerHTML = '<option value="">Выберите…</option>';
@@ -210,16 +212,19 @@ $(document).on('click', '.order-delete', function(e) {
             subcatRow.style.display = 'none';
             return;
         }
-        fetch(`${window.location.origin}/wp-json/wp/v2/product_cat?parent=${catId}&per_page=100`)
-            .then(r=>r.json())
-            .then(data=>{
-                if(Array.isArray(data) && data.length){
+        fetch(`${restUrl}?parent=${catId}&per_page=100`)
+            .then(r => r.json())
+            .then(data => {
+                if (Array.isArray(data) && data.length) {
                     subcatSelect.innerHTML = '<option value="">Выберите…</option>' +
-                        data.map(t=>`<option value="${t.id}" ${selected==t.id?'selected':''}>${t.name}</option>`).join('');
+                        data.map(t => `<option value="${t.id}" ${selected==t.id?'selected':''}>${t.name}</option>`).join('');
                     subcatRow.style.display = '';
-                }else{
+                } else {
                     subcatRow.style.display = 'none';
                 }
+            })
+            .catch(() => {
+                subcatRow.style.display = 'none';
             });
     }
 

--- a/functions.php
+++ b/functions.php
@@ -47,7 +47,7 @@ function mytheme_enqueue_assets() {
 
     /* основные скрипты */
     wp_enqueue_script( 'splide-js',  get_template_directory_uri() . '/assets/libs/splide/splide.min.js', [], '4.1.3', true );
-    wp_enqueue_script( 'mytheme-js', get_template_directory_uri() . '/assets/js/theme.js', [ 'splide-js' ], '1.1', true );
+    wp_enqueue_script( 'mytheme-js', get_template_directory_uri() . '/assets/js/theme.js', [ 'splide-js' ], '1.2', true );
 
     /* AJAX-скрипт избранного */
     wp_enqueue_script(


### PR DESCRIPTION
## Summary
- fetch subcategories dynamically when category is selected
- bump theme script version so cache gets invalidated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8f938640832190833188a907657c