### PR TITLE
Fix missing subcategory listing

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -232,3 +232,5 @@ $(document).on('click', '.order-delete', function(e) {
         loadSubcats(catSelect.value || '', subcatSelect.dataset.selected || '');
     }
 });
+});
+})();

--- a/inc/dashboard/dashboard-functions.php
+++ b/inc/dashboard/dashboard-functions.php
@@ -61,6 +61,14 @@ function mytheme_handle_save_ad() {
     update_post_meta( $post_id, '_ad_category',    $cat_slug );
     update_post_meta( $post_id, '_ad_subcategory', $subcat_slug );
 
+    // Also assign WooCommerce product categories for taxonomy archives
+    if ( function_exists( 'wp_set_object_terms' ) ) {
+        $terms = array_filter( [ $cat_slug, $subcat_slug ] );
+        if ( $terms ) {
+            wp_set_object_terms( $post_id, $terms, 'product_cat', false );
+        }
+    }
+
     // 6) Собираем существующую галерею
     $existing = array_filter( array_map( 'absint',
         explode( ',', get_post_meta( $post_id, '_product_image_gallery', true ) )


### PR DESCRIPTION
## Summary
- assign `product_cat` terms when saving ads so listings show in subcategory archives

## Testing
- `node --check assets/js/theme.js`
- `node -e "const fs=require('fs');try{new Function(fs.readFileSync('assets/js/theme.js','utf8'));console.log('parse ok');}catch(e){console.error('parse error',e);process.exit(1);}"`
- `php -l inc/dashboard/dashboard-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb4bec10883218f19eea7db7eb58a